### PR TITLE
Sample enums usage

### DIFF
--- a/src/main/java/frc/robot/Controllers.java
+++ b/src/main/java/frc/robot/Controllers.java
@@ -13,8 +13,6 @@ public final class Controllers {
   public static int DRIVER_SEC_PORT = 0;
   public static int DRIVER_TURN = 4;
   public static int DRIVER_SPEED = 1;
-  // public static int HIGHSPEED = 2;
-  // public static int LOWSPEED = 1; // 0.5
   public static double LOWEREDSPEED = 0.55;
   public static boolean DRIVER_W_BUTTONS = false;
   public static Controllers.Gears CURRENT_SPEEDLIMIT = Gears.HIGH;

--- a/src/main/java/frc/robot/Controllers.java
+++ b/src/main/java/frc/robot/Controllers.java
@@ -2,16 +2,22 @@ package frc.robot;
 
 public final class Controllers {
 
+  // Create options for what gears the drivetrain can use.
+  public enum Gears {
+    LOW,
+    HIGH
+  }
+
   // Default Driver Controller configuraton (Xbox Pro)
   public static int DRIVER_ONE_PORT = 0;
   public static int DRIVER_SEC_PORT = 0;
   public static int DRIVER_TURN = 4;
   public static int DRIVER_SPEED = 1;
-  public static int HIGHSPEED = 2;
-  public static int LOWSPEED = 1; // 0.5
+  // public static int HIGHSPEED = 2;
+  // public static int LOWSPEED = 1; // 0.5
   public static double LOWEREDSPEED = 0.55;
   public static boolean DRIVER_W_BUTTONS = false;
-  public static int CURRENT_SPEEDLIMIT = 2;
+  public static Controllers.Gears CURRENT_SPEEDLIMIT = Gears.HIGH;
   public static boolean arcadedriver = true;
 
   // Operator Controller Configuration (Logitech Dual Action)

--- a/src/main/java/frc/robot/commands/TeleopCmd.java
+++ b/src/main/java/frc/robot/commands/TeleopCmd.java
@@ -29,9 +29,9 @@ public class TeleopCmd extends CommandBase {
 
   public double getGear() {
     double returned = 1.0;
-    if (Controllers.CURRENT_SPEEDLIMIT == Controllers.HIGHSPEED) {
+    if (Controllers.CURRENT_SPEEDLIMIT == Controllers.Gears.HIGH) {
       returned = 1.0;
-    } else if (Controllers.CURRENT_SPEEDLIMIT == Controllers.LOWSPEED) {
+    } else if (Controllers.CURRENT_SPEEDLIMIT == Controllers.Gears.LOW) {
       returned = Controllers.LOWEREDSPEED;
     }
     return returned;

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -101,11 +101,11 @@ public class DrivetrainSubsystem extends SubsystemBase {
   }
 
   public void speedup() {
-    Controllers.CURRENT_SPEEDLIMIT = Controllers.HIGHSPEED;
+    Controllers.CURRENT_SPEEDLIMIT = Controllers.Gears.HIGH;
   }
 
   public void speeddown() {
-    Controllers.CURRENT_SPEEDLIMIT = Controllers.LOWSPEED;
+    Controllers.CURRENT_SPEEDLIMIT = Controllers.Gears.LOW;
   }
 
   public void teleop(double speed, double turn) {


### PR DESCRIPTION
Since choosing between high and low gear don't actually need to be any numbers, we can use an enum to list the options and remove the number to avoid confusion between numbers for use with speed and numbers that are just arbitrary. 

Ref: https://www.w3schools.com/java/java_enums.asp