### PR TITLE
add pr check to prevent brushed motor types being added

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,3 +46,15 @@ jobs:
 
       - run: ./gradlew spotlessCheck
 
+  custom-checks:
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Running custom checks from pr-check.sh.
+        run: bash pr-check.sh
+

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if find . -name '*.java' -exec grep MotorType.kBrushed {} +; then
+    echo ''
+    echo 'ERROR:'
+    echo 'ERROR:  Found references to unallowed MotorType.kBrushed types in the above files.'
+    echo 'ERROR:'
+    echo ''
+    exit 1
+fi


### PR DESCRIPTION
This will add a 3rd and custom check to PRs.

1. spotless - ensures code formatting and readability
2. gradlew build - ensures the java code doesn't have any syntax errors
3. custom check - ensures there are no references to `MotorType.kBrushed` in any java files.